### PR TITLE
test entitlement certificates that expire in the far future

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,7 @@ You need a ZIP file with the following files in the root of the archive:
 * `rhcert_expired.pem` — This must be an expired Red Hat content certificate.
 * `rhcert_incompatible.pem` — This must be a Red Hat content certificate containing one or more entitlements that are not compatible with RHUI (containing a non-RHUI repository path) and no compatible entitlement at all.
 * `rhcert_partially_invalid.pem` — This must be a Red Hat content certificate containing one or more entitlements that are not compatible with RHUI (containing a non-RHUI repository path) but also at least one compatible entitlement.
+* `entcert_longlife.crt` — This must be an entitlement certificate that expires far in the future, in 25 years or later.
 * `rhui-rpm-upload-test-1-1.noarch.rpm` — This package will be uploaded to a custom repository.
 * `rhui-rpm-upload-trial-1-1.noarch.rpm` — This package will also be uploaded to a custom repository. It must be signed with the RHUI QE GPG key.
 * `rhui-rpm-upload-tryout-1-1.noarch.rpm` — This package will also be uploaded to a custom repository. It must be signed with a key different from RHUI QE.

--- a/tests/rhui4_tests/test_client_management.py
+++ b/tests/rhui4_tests/test_client_management.py
@@ -147,7 +147,8 @@ class TestClient():
         RHUIManagerClient.generate_ent_cert(RHUA,
                                             [CUSTOM_REPO, self.yum_repo_name],
                                             "test_ent_cli",
-                                            "/root/")
+                                            "/root/",
+                                            35*365)
         Expect.expect_retval(RHUA, "test -f /root/test_ent_cli.crt")
         Expect.expect_retval(RHUA, "test -f /root/test_ent_cli.key")
 

--- a/tests/rhui4_tests/test_entitlements.py
+++ b/tests/rhui4_tests/test_entitlements.py
@@ -4,6 +4,7 @@ from os.path import basename
 
 import logging
 import nose
+from stitches.expect import Expect
 
 from rhui4_tests_lib.conmgr import ConMgr
 from rhui4_tests_lib.rhuimanager import RHUIManager
@@ -171,6 +172,16 @@ class TestEntitlement():
                                  RHUA,
                                  cert)
 
+
+    @staticmethod
+    def test_17_check_longlife_cert():
+        '''
+           check if a certificate that won't expire until a few decades later can be used
+        '''
+        cert = "/tmp/extra_rhui_files/entcert_longlife.crt"
+        cmd = "python3.11 -c \"from rhsm import certificate;" \
+                             f"certificate.create_from_file('{cert}')\""
+        Expect.expect_retval(RHUA, cmd)
 
     @staticmethod
     def teardown_class():

--- a/tests/rhui4_tests_lib/rhuimanager_client.py
+++ b/tests/rhui4_tests_lib/rhuimanager_client.py
@@ -28,7 +28,7 @@ class RHUIManagerClient():
         Expect.expect(connection, "Local directory in which to save the generated certificate.*:")
         Expect.enter(connection, dirname)
         Expect.expect(connection, "Number of days the certificate should be valid.*:")
-        Expect.enter(connection, validity_days)
+        Expect.enter(connection, str(validity_days))
         RHUIManager.proceed_without_check(connection)
         RHUIManager.quit(connection, timeout=60)
 


### PR DESCRIPTION
There was a bug in python-rhsm that prevented CDSes from handling certificates with a very long expiration period. This is fixed in RHUI 4.11.1+.

This update modifies one of the test cases to create such a cert, and also adds a quick check on the RHUA with a supplied test cert. As always, this cert is supposed to exist in the extra_files.zip file, which isn't part of the public git repo.